### PR TITLE
Save rendered meme to files

### DIFF
--- a/api/src/main/java/com/exelaration/abstractmemery/services/FileStorageService.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/FileStorageService.java
@@ -1,7 +1,5 @@
 package com.exelaration.abstractmemery.services;
 
-import java.io.InputStream;
-
 public interface FileStorageService {
-  public void save(String fileName, InputStream file);
+  public void save(String fileName, String urlData, String storageLocation);
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/FileStorageServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/FileStorageServiceImpl.java
@@ -3,32 +3,34 @@ package com.exelaration.abstractmemery.services.implementations;
 import com.exelaration.abstractmemery.services.FileStorageService;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import org.springframework.stereotype.Service;
 
 @Service("fileStorageService")
 public class FileStorageServiceImpl implements FileStorageService {
-  private static final String uploadingDir = "/app/src/main/resources/images/";
 
-  public void save(String fileName, InputStream fileStream) {
+  public void save(String fileName, String urlData, String storageLocation) {
+    String uploadingDir = "/app/src/main/resources/" + storageLocation;
+    createDirectory(uploadingDir);
     String fileLocation = "";
-    createDirectory();
     if (fileName.equals("")) {
       throw new RuntimeException("You must select the a file for uploading");
     }
     try {
       fileLocation = (uploadingDir + fileName);
       Path path = Paths.get(fileLocation);
-      Files.write(path, fileStream.readAllBytes());
+      byte[] decodedBytes = Base64.getDecoder().decode(urlData);
+      Files.write(path, decodedBytes);
+
     } catch (IOException e) {
       e.printStackTrace();
     }
   }
 
-  private void createDirectory() {
-    new File(uploadingDir).mkdirs();
+  private void createDirectory(String uploadDirectory) {
+    new File(uploadDirectory).mkdirs();
   }
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/ImageServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/ImageServiceImpl.java
@@ -19,9 +19,10 @@ public class ImageServiceImpl implements ImageService {
   public Image save(MultipartFile file) {
     Image image = new Image();
     String fileName = "";
+    String fileData = "";
     try {
       byte[] bytes = file.getBytes();
-      String fileData = Base64.encodeBase64String(bytes);
+      fileData = Base64.encodeBase64String(bytes);
       fileName = file.getOriginalFilename();
 
       image.setFileData(fileData);
@@ -31,7 +32,7 @@ public class ImageServiceImpl implements ImageService {
       e.printStackTrace();
     }
     try {
-      fileStorageService.save(fileName, file.getInputStream());
+      fileStorageService.save(fileName, fileData, "images/");
       return metadataService.save(image);
 
     } catch (Exception e) {

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.exelaration.abstractmemery.services.implementations;
 
 import com.exelaration.abstractmemery.domains.Meme;
+import com.exelaration.abstractmemery.services.FileStorageService;
 import com.exelaration.abstractmemery.services.MemeMetadataService;
 import com.exelaration.abstractmemery.services.MemeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +10,20 @@ import org.springframework.stereotype.Service;
 @Service("memeService")
 public class MemeServiceImpl implements MemeService {
 
-  @Autowired MemeMetadataService memeMetadataService;
+  @Autowired private MemeMetadataService memeMetadataService;
+  @Autowired private FileStorageService fileStorageService;
 
   public Meme save(Meme meme) {
-    return memeMetadataService.save(meme);
+    try {
+      String memeUrl = meme.getMemeUrl();
+      memeUrl = memeUrl.replaceAll("data:image/png;base64,", "");
+      meme.setMemeName(meme.getMemeName() + ".jpg");
+
+      fileStorageService.save(meme.getMemeName(), memeUrl, "memes/");
+      return memeMetadataService.save(meme);
+
+    } catch (Exception e) {
+      return null;
+    }
   }
 }

--- a/api/src/test/java/com/exelaration/abstractmemery/services/ImageServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/ImageServiceTest.java
@@ -46,7 +46,8 @@ public class ImageServiceTest {
     Image actualImage = imageService.save(mockMultipartFile);
 
     assertEquals(expectedImage.getFileName(), actualImage.getFileName());
-    verify(fileStorageService).save(Mockito.eq("test-image.png"), Mockito.any());
+    verify(fileStorageService)
+        .save(Mockito.eq("test-image.png"), Mockito.any(), Mockito.eq("images/"));
   }
 
   @Test
@@ -65,7 +66,9 @@ public class ImageServiceTest {
         new MockMultipartFile(
             "user-image", "test-image.png", "image/png", "test-image.png".getBytes());
 
-    doThrow(new RuntimeException()).when(fileStorageService).save(Mockito.any(), Mockito.any());
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .save(Mockito.any(), Mockito.any(), Mockito.any());
     assertNull(imageService.save(mockMultipartFile));
   }
 }

--- a/api/src/test/java/com/exelaration/abstractmemery/services/MemeServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/MemeServiceTest.java
@@ -1,0 +1,79 @@
+package com.exelaration.abstractmemery.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.exelaration.abstractmemery.domains.Meme;
+import com.exelaration.abstractmemery.services.implementations.MemeServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class MemeServiceTest {
+
+  @Mock private FileStorageService fileStorageService;
+
+  @Mock private MemeMetadataService memeMetadataService;
+
+  @InjectMocks private MemeServiceImpl memeService;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void save_WhenMemeSavedSuccessfully_ExpectMemeReturned() {
+    Meme mockMeme = new Meme();
+    mockMeme.setMemeName("test-image");
+    mockMeme.setMemeUrl("data:image/png;base64,imageData");
+
+    Meme expectedMeme = new Meme();
+    expectedMeme.setMemeName("test-image.jpg");
+    expectedMeme.setMemeUrl("imageData");
+
+    Mockito.when(memeMetadataService.save(Mockito.any())).thenReturn(expectedMeme);
+
+    Meme actualMeme = memeService.save(mockMeme);
+
+    assertEquals(expectedMeme.getMemeName(), actualMeme.getMemeName());
+    assertEquals(expectedMeme.getMemeUrl(), actualMeme.getMemeUrl());
+
+    verify(fileStorageService)
+        .save(Mockito.eq("test-image.jpg"), Mockito.any(), Mockito.eq("memes/"));
+  }
+
+  @Test
+  public void memeServiceSave_WhenMetadataSaveUnsuccessful_ExpectNull() {
+    Meme mockMeme = new Meme();
+    mockMeme.setMemeName("test-image");
+    mockMeme.setTopText("top text");
+    mockMeme.setBottomText("bottom text");
+    mockMeme.setMemeUrl("data:image/png;base64,imageData");
+
+    Mockito.when(memeMetadataService.save(Mockito.any())).thenThrow(new IllegalArgumentException());
+    assertNull(memeService.save(mockMeme));
+  }
+
+  @Test
+  public void memeServiceSave_WhenFileStorageSaveUnsuccessful_ExpectNull() {
+    Meme mockMeme = new Meme();
+    mockMeme.setMemeName("test-image");
+    mockMeme.setTopText("top text");
+    mockMeme.setBottomText("bottom text");
+    mockMeme.setMemeUrl("data:image/png;base64,imageData");
+
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .save(Mockito.any(), Mockito.any(), Mockito.any());
+    assertNull(memeService.save(mockMeme));
+  }
+}


### PR DESCRIPTION
This PR adds the ability to save the rendered meme to the file system. `FileStorageService` and `FileStorageServiceImpl` were adjusted to allow `MemeService` to use it too, which caused `ImageService` to need a few adjustments