### PR TITLE
Create user api

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	testCompile('org.junit.jupiter:junit-jupiter-engine:5.2.0')
 	testCompile('org.mockito:mockito-junit-jupiter:2.23.0')
 	testRuntime('org.flywaydb:flyway-core:6.2.3')
+	compile("com.auth0:java-jwt:3.4.0")
 }
 
 

--- a/api/src/main/java/com/exelaration/abstractmemery/AbstractMemeryApplication.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/AbstractMemeryApplication.java
@@ -2,10 +2,16 @@ package com.exelaration.abstractmemery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@SpringBootApplication
 public class AbstractMemeryApplication {
+
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
   public static void main(String[] args) {
     SpringApplication.run(AbstractMemeryApplication.class, args);

--- a/api/src/main/java/com/exelaration/abstractmemery/constants/SecurityConstants.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/constants/SecurityConstants.java
@@ -1,0 +1,9 @@
+package com.exelaration.abstractmemery.constants;
+
+public class SecurityConstants {
+  public static final String SECRET = "SecretKeyToGenJWTs";
+  public static final long EXPIRATION_TIME = 864_000_000; // 10 days
+  public static final String TOKEN_PREFIX = "Bearer ";
+  public static final String HEADER_STRING = "Authorization";
+  public static final String SIGN_UP_URL = "/users/sign-up";
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/controllers/UserController.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/controllers/UserController.java
@@ -1,0 +1,25 @@
+package com.exelaration.abstractmemery.controllers;
+
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+  @Autowired private UserDetailsServiceImpl userDetailsService;
+
+  @PostMapping("/sign-up")
+  public String signUp(@RequestBody ApplicationUser user) {
+    if (!userDetailsService.userExists(user.getUsername())) {
+      userDetailsService.saveUser(user);
+      return "User has been created";
+    }
+    return "User already exists";
+  }
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/domains/ApplicationUser.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/domains/ApplicationUser.java
@@ -1,0 +1,22 @@
+package com.exelaration.abstractmemery.domains;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "users")
+public class ApplicationUser {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+
+  private String username;
+
+  private String password;
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/filters/JWTAuthenticationFilter.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/filters/JWTAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package com.exelaration.abstractmemery.filters;
+
+import static com.auth0.jwt.algorithms.Algorithm.HMAC512;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.EXPIRATION_TIME;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.HEADER_STRING;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.SECRET;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.auth0.jwt.JWT;
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+  @Autowired private AuthenticationManager authenticationManager;
+
+  public JWTAuthenticationFilter(AuthenticationManager authenticationManager) {
+    this.authenticationManager = authenticationManager;
+  }
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res)
+      throws AuthenticationException {
+    try {
+      ApplicationUser creds =
+          new ObjectMapper().readValue(req.getInputStream(), ApplicationUser.class);
+
+      return authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(
+              creds.getUsername(), creds.getPassword(), new ArrayList<>()));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void successfulAuthentication(
+      HttpServletRequest req, HttpServletResponse res, FilterChain chain, Authentication auth)
+      throws IOException, ServletException {
+
+    String token =
+        JWT.create()
+            .withSubject(((User) auth.getPrincipal()).getUsername())
+            .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+            .sign(HMAC512(SECRET.getBytes()));
+    res.addHeader(HEADER_STRING, TOKEN_PREFIX + token);
+  }
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/filters/JWTAuthorizationFilter.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/filters/JWTAuthorizationFilter.java
@@ -1,0 +1,60 @@
+package com.exelaration.abstractmemery.filters;
+
+import static com.exelaration.abstractmemery.constants.SecurityConstants.HEADER_STRING;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.SECRET;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.TOKEN_PREFIX;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import java.io.IOException;
+import java.util.ArrayList;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
+
+  public JWTAuthorizationFilter(AuthenticationManager authManager) {
+    super(authManager);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+      throws IOException, ServletException {
+    String header = req.getHeader(HEADER_STRING);
+
+    if (header == null || !header.startsWith(TOKEN_PREFIX)) {
+      chain.doFilter(req, res);
+      return;
+    }
+
+    UsernamePasswordAuthenticationToken authentication = getAuthentication(req);
+
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+    chain.doFilter(req, res);
+  }
+
+  private UsernamePasswordAuthenticationToken getAuthentication(HttpServletRequest request) {
+    String token = request.getHeader(HEADER_STRING);
+    if (token != null) {
+      // parse the token.
+      String user =
+          JWT.require(Algorithm.HMAC512(SECRET.getBytes()))
+              .build()
+              .verify(token.replace(TOKEN_PREFIX, ""))
+              .getSubject();
+
+      if (user != null) {
+        return new UsernamePasswordAuthenticationToken(user, null, new ArrayList<>());
+      }
+      return null;
+    }
+    return null;
+  }
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/repositories/UserRepository.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/repositories/UserRepository.java
@@ -1,0 +1,8 @@
+package com.exelaration.abstractmemery.repositories;
+
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<ApplicationUser, Integer> {
+  ApplicationUser findByUsername(String username);
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/security/WebSecurity.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/security/WebSecurity.java
@@ -1,0 +1,63 @@
+package com.exelaration.abstractmemery.security;
+
+import static com.exelaration.abstractmemery.constants.SecurityConstants.SIGN_UP_URL;
+
+import com.exelaration.abstractmemery.filters.JWTAuthenticationFilter;
+import com.exelaration.abstractmemery.filters.JWTAuthorizationFilter;
+import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@EnableWebSecurity
+public class WebSecurity extends WebSecurityConfigurerAdapter {
+
+  @Autowired private UserDetailsServiceImpl userDetailsService;
+  private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+  public WebSecurity(
+      UserDetailsServiceImpl userDetailsService, BCryptPasswordEncoder bCryptPasswordEncoder) {
+    this.userDetailsService = userDetailsService;
+    this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+  }
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http.cors()
+        .and()
+        .csrf()
+        .disable()
+        .authorizeRequests()
+        .antMatchers(HttpMethod.POST, SIGN_UP_URL)
+        .permitAll()
+        .anyRequest()
+        .authenticated()
+        .and()
+        .addFilter(new JWTAuthenticationFilter(authenticationManager()))
+        .addFilter(new JWTAuthorizationFilter(authenticationManager()))
+        // this disables session creation on Spring Security
+        .sessionManagement()
+        .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+  }
+
+  @Override
+  public void configure(AuthenticationManagerBuilder auth) throws Exception {
+    auth.userDetailsService(userDetailsService).passwordEncoder(bCryptPasswordEncoder);
+  }
+
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", new CorsConfiguration().applyPermitDefaultValues());
+    return source;
+  }
+}

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/UserDetailsServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/UserDetailsServiceImpl.java
@@ -1,0 +1,49 @@
+package com.exelaration.abstractmemery.services.implementations;
+
+import static java.util.Collections.emptyList;
+
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import com.exelaration.abstractmemery.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service("userDetailsService")
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+  @Autowired private BCryptPasswordEncoder bCryptPasswordEncoder;
+  @Autowired private UserRepository userRepository;
+
+  public UserDetailsServiceImpl(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public ApplicationUser saveUser(ApplicationUser user) {
+    user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+    try {
+      return userRepository.save(user);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  public boolean userExists(String username) {
+    if (userRepository.findByUsername(username) == null) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    ApplicationUser applicationUser = userRepository.findByUsername(username);
+    if (applicationUser == null) {
+      throw new UsernameNotFoundException(username);
+    }
+    return new User(applicationUser.getUsername(), applicationUser.getPassword(), emptyList());
+  }
+}

--- a/api/src/main/resources/db/migration/V9__CreateUsersTable.sql
+++ b/api/src/main/resources/db/migration/V9__CreateUsersTable.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS Users (
+    id SERIAL NOT NULL PRIMARY KEY,
+    username VARCHAR(200),
+    password VARCHAR(200)
+);

--- a/api/src/test/java/com/exelaration/abstractmemery/controllers/UserControllerTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/controllers/UserControllerTest.java
@@ -1,0 +1,96 @@
+package com.exelaration.abstractmemery.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = UserController.class)
+public class UserControllerTest {
+  private MockMvc mockMvc;
+  @Autowired private UserController userController;
+  @MockBean private UserDetailsServiceImpl userDetailsService;
+
+  @BeforeEach
+  public void setUp() {
+    this.mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+  }
+
+  @Test
+  public void UserControllerTest_WhenNewUserRegisters_ExpectStatus200() throws Exception {
+    ResultMatcher ok = MockMvcResultMatchers.status().isOk();
+    String url = "/users/sign-up";
+    String expectedMessage = "User has been created";
+
+    ApplicationUser testUser = new ApplicationUser();
+    testUser.setUsername("testUser@gmail.com");
+    testUser.setPassword("ABC123abc!");
+
+    when(userDetailsService.saveUser(any())).thenReturn(testUser);
+    when(userDetailsService.userExists(testUser.getUsername())).thenReturn(false);
+
+    assertEquals(expectedMessage, userController.signUp(testUser));
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(testUser)))
+        .andExpect(ok);
+  }
+
+  @Test
+  public void UserControllerTest_WhenExistingUserRegisters_ExpectStatus200() throws Exception {
+    ResultMatcher ok = MockMvcResultMatchers.status().isOk();
+    String url = "/users/sign-up";
+    String expectedMessage = "User already exists";
+
+    ApplicationUser testUser = new ApplicationUser();
+    testUser.setUsername("testUser@gmail.com");
+    testUser.setPassword("ABC123abc!");
+
+    when(userDetailsService.saveUser(any())).thenReturn(testUser);
+    when(userDetailsService.userExists(testUser.getUsername())).thenReturn(true);
+
+    assertEquals(expectedMessage, userController.signUp(testUser));
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(testUser)))
+        .andExpect(ok);
+  }
+
+  @Test
+  public void UserControllerTest_WhenRegisterFails_ExpectStatus400() throws Exception {
+    ResultMatcher badRequest = MockMvcResultMatchers.status().isBadRequest();
+    String url = "/users/sign-up";
+
+    ApplicationUser testUser = null;
+
+    when(userDetailsService.saveUser(any())).thenReturn(testUser);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().writeValueAsString(testUser)))
+        .andExpect(badRequest);
+  }
+}

--- a/api/src/test/java/com/exelaration/abstractmemery/services/UserDetailsServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/UserDetailsServiceTest.java
@@ -1,0 +1,77 @@
+package com.exelaration.abstractmemery.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+
+import com.exelaration.abstractmemery.domains.ApplicationUser;
+import com.exelaration.abstractmemery.repositories.UserRepository;
+import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+public class UserDetailsServiceTest {
+  @Mock private BCryptPasswordEncoder BCryptPasswordEncoder;
+
+  @Mock private UserRepository userRepository;
+
+  @InjectMocks private UserDetailsServiceImpl userDetailsService;
+
+  @BeforeEach
+  public void init() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void UserDetailsSaveUser_WhenUserSavesSuccessfully_ExpectUser() {
+    ApplicationUser expectedUser = new ApplicationUser();
+    expectedUser.setUsername("admin");
+    expectedUser.setPassword("password");
+
+    Mockito.when(userRepository.save(Mockito.any())).thenReturn(expectedUser);
+
+    ApplicationUser actualUser = userDetailsService.saveUser(expectedUser);
+    expectedUser.setPassword(BCryptPasswordEncoder.encode(expectedUser.getPassword()));
+    assertEquals(expectedUser, actualUser);
+  }
+
+  @Test
+  public void UserDetailsSaveUser_WhenUserSaveUnsuccessful_ExpectNull() {
+    ApplicationUser user = new ApplicationUser();
+    Mockito.when(userRepository.save(Mockito.any())).thenThrow(new IllegalArgumentException());
+    assertNull(userDetailsService.saveUser(user));
+    verify(BCryptPasswordEncoder).encode(Mockito.eq(user.getPassword()));
+  }
+
+  @Test
+  public void UserDetailsLoadUserByUsername_WhenGivenValidUsername_ExpectUser() {
+    ApplicationUser expectedUser = new ApplicationUser();
+    expectedUser.setUsername("admin");
+    expectedUser.setPassword("password");
+
+    Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(expectedUser);
+    UserDetails actualUser = userDetailsService.loadUserByUsername(expectedUser.getUsername());
+    assertEquals(expectedUser.getUsername(), actualUser.getUsername());
+  }
+
+  @Test
+  public void UserDetailsLoadUserByUsername_WhenUserNotFound_ExpectUserNotFoundException() {
+    Mockito.when(userRepository.findByUsername(Mockito.any())).thenReturn(null);
+    assertThrows(
+        UsernameNotFoundException.class,
+        () -> {
+          userDetailsService.loadUserByUsername("admin");
+        });
+  }
+}


### PR DESCRIPTION
In this PR I have created the user API and created spring filters for login.  When you hit the /login endpoint, it hits the `JWTAuthenicationFilter.java` file.  You need to pass a username and password and it will return a JWT.  If you pass a username and password thats not in the database you will receive a 403 unauthorized.  You can register a new user by hitting the users/sign-up endpoint and passing it a username and password.  This will store it in the database.  Every time you try to hit an endpoint in the API it will look for the JWT in the request through the `JWTAuthorizationFilter.java`. If you do not have the JWT, it will give a 403 error.  I re-enabled Spring Security however it is allowing all users to hit the /meme/, /upload/, and users/sign-up endpoints without authentication.
I followed https://auth0.com/blog/implementing-jwt-authentication-on-spring-boot/#Enabling-User-Registration-on-Spring-Boot-APIs 