### PR TITLE
add validation so that image must be uploaded on meme submission

### DIFF
--- a/ui/src/MemeUpload.tsx
+++ b/ui/src/MemeUpload.tsx
@@ -53,8 +53,8 @@ function MemeUpload(props: MemeProps) {
   function formSubmitHandler(event: any) {
     event.preventDefault();
     let error = "";
-    if (topText.length === 0 && bottomText.length === 0) {
-      error = "You must add either a top or bottom caption or both.";
+    if ((topText.length === 0 && bottomText.length === 0) || props.imageID === 0) {
+      error = "You must add either a top or bottom caption or both with an uploaded image.";
       setErrorMessage(error);
     } else {
       generateMeme().then((dataUrl: string) => {


### PR DESCRIPTION
When testing master I found this bug, so I added it to the error check on meme submission. 

This is another instance that prevents imageID and memeID from getting out of sync.