### PR TITLE
add user settings page

### DIFF
--- a/api/src/main/java/com/exelaration/abstractmemery/constants/SecurityConstants.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/constants/SecurityConstants.java
@@ -6,6 +6,7 @@ public class SecurityConstants {
   public static final String TOKEN_PREFIX = "Bearer ";
   public static final String HEADER_STRING = "Authorization";
   public static final String SIGN_UP_URL = "/users/sign-up";
+  public static final String SETTINGS_URL = "/users/settings";
   public static final String GALLERY_URL = "/meme";
   public static final String DIRECT_MEME_LINK = "/meme/*";
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/controllers/UserController.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/controllers/UserController.java
@@ -4,6 +4,7 @@ import com.exelaration.abstractmemery.domains.ApplicationUser;
 import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,15 @@ public class UserController {
     if (!userDetailsService.userExists(user.getUsername())) {
       userDetailsService.saveUser(user);
       return "User has been created";
+    }
+    return "User already exists";
+  }
+
+  @PutMapping("/settings")
+  public String updateSettings(@RequestBody ApplicationUser user) {
+    if (!userDetailsService.userExists(user.getUsername())) {
+      userDetailsService.saveUser(user);
+      return "User has been updated";
     }
     return "User already exists";
   }

--- a/api/src/main/java/com/exelaration/abstractmemery/security/WebSecurity.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/security/WebSecurity.java
@@ -2,6 +2,7 @@ package com.exelaration.abstractmemery.security;
 
 import static com.exelaration.abstractmemery.constants.SecurityConstants.DIRECT_MEME_LINK;
 import static com.exelaration.abstractmemery.constants.SecurityConstants.GALLERY_URL;
+import static com.exelaration.abstractmemery.constants.SecurityConstants.SETTINGS_URL;
 import static com.exelaration.abstractmemery.constants.SecurityConstants.SIGN_UP_URL;
 
 import com.exelaration.abstractmemery.filters.JWTAuthenticationFilter;
@@ -51,7 +52,9 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers(HttpMethod.POST, SIGN_UP_URL)
         .permitAll()
-        .anyRequest()
+        .and()
+        .authorizeRequests()
+        .antMatchers(HttpMethod.PUT, SETTINGS_URL)
         .authenticated()
         .and()
         .addFilter(new JWTAuthenticationFilter(authenticationManager(), userRepository))

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/UserDetailsServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/UserDetailsServiceImpl.java
@@ -23,7 +23,14 @@ public class UserDetailsServiceImpl implements UserDetailsService {
   }
 
   public ApplicationUser saveUser(ApplicationUser user) {
-    user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+    if (user.getUsername().length() == 0) {
+      user.setUsername(userRepository.findById(user.getId()).get().getUsername());
+    }
+    if (user.getPassword() != null && user.getPassword().length() > 0) {
+      user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+    } else {
+      user.setPassword(userRepository.findById(user.getId()).get().getPassword());
+    }
     try {
       return userRepository.save(user);
     } catch (Exception e) {

--- a/api/src/test/java/com/exelaration/abstractmemery/services/UserDetailsServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/UserDetailsServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import com.exelaration.abstractmemery.domains.ApplicationUser;
 import com.exelaration.abstractmemery.repositories.UserRepository;
 import com.exelaration.abstractmemery.services.implementations.UserDetailsServiceImpl;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,11 +48,46 @@ public class UserDetailsServiceTest {
   }
 
   @Test
+  public void saveUser_WhenUserSavesWithNoUsernameProvided_ExpectUser() {
+    ApplicationUser expectedUser = new ApplicationUser();
+    expectedUser.setPassword("password");
+    Optional<ApplicationUser> expectedUserOpt = Optional.of(expectedUser);
+    expectedUserOpt.get().setUsername("username");
+
+    Mockito.when(userRepository.findById(Mockito.any())).thenReturn(expectedUserOpt);
+    Mockito.when(userRepository.save(Mockito.any())).thenReturn(expectedUser);
+
+    expectedUser.setUsername(expectedUserOpt.get().getUsername());
+    ApplicationUser actualUser = userDetailsService.saveUser(expectedUser);
+    expectedUser.setPassword(BCryptPasswordEncoder.encode(expectedUser.getPassword()));
+    assertEquals(expectedUser, actualUser);
+  }
+
+  @Test
+  public void saveUser_WhenUserSavesWithNoPasswordProvided_ExpectUser() {
+    ApplicationUser expectedUser = new ApplicationUser();
+    expectedUser.setUsername("username");
+    Optional<ApplicationUser> expectedUserOpt = Optional.of(expectedUser);
+    expectedUserOpt.get().setPassword("password");
+
+    Mockito.when(userRepository.findById(Mockito.any())).thenReturn(expectedUserOpt);
+    Mockito.when(userRepository.save(Mockito.any())).thenReturn(expectedUser);
+
+    expectedUser.setUsername(expectedUserOpt.get().getPassword());
+    ApplicationUser actualUser = userDetailsService.saveUser(expectedUser);
+    expectedUser.setPassword(BCryptPasswordEncoder.encode(expectedUser.getPassword()));
+    assertEquals(expectedUser, actualUser);
+  }
+
+  @Test
   public void saveUser_WhenUserSaveUnsuccessful_ExpectNull() {
-    ApplicationUser user = new ApplicationUser();
+    ApplicationUser expectedUser = new ApplicationUser();
+    expectedUser.setUsername("admin");
+    expectedUser.setPassword("password");
+
     Mockito.when(userRepository.save(Mockito.any())).thenThrow(new IllegalArgumentException());
-    assertNull(userDetailsService.saveUser(user));
-    verify(BCryptPasswordEncoder).encode(Mockito.eq(user.getPassword()));
+    assertNull(userDetailsService.saveUser(expectedUser));
+    verify(BCryptPasswordEncoder).encode(Mockito.eq("password"));
   }
 
   @Test

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import Login from "./Login";
 import SignUp from "./SignUp";
 import Gallery from "./MemeGallery";
 import SearchResults from "./SearchResults";
+import UserSettings from "./UserSettings";
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
         <Route path="/memes/:memeID" component={MemePage} exact />
         <Route path="/create-meme" component={CreateMeme} exact />
         <Route path="/search/:text" component={SearchResults} exact />
+        <Route path="/user/settings" component={UserSettings} exact />
         <Route component={RouterError} />
       </Switch>
     </Router>

--- a/ui/src/Login.tsx
+++ b/ui/src/Login.tsx
@@ -28,7 +28,7 @@ interface MetadataObj {
 
 function Login() {
   // eslint-disable-next-line
-  const [cookies, setCookie] = useCookies(["userToken", "userId"]);
+  const [cookies, setCookie] = useCookies(["userToken", "userId", "username"]);
   const history = useHistory();
   const { handleSubmit, handleChange, values, errors } = useFormik({
     initialValues: {
@@ -47,6 +47,7 @@ function Login() {
           let token = res.headers["authorization"].replace("Bearer ", "");
           let decodedToken: MetadataObj = jwtDecode(token);
           setCookie("userId", decodedToken["id"], { path: "/" });
+          setCookie("username", decodedToken["sub"], { path: "/" });
           history.push("/create-meme");
         })
         .catch((error) => {

--- a/ui/src/MemeUpload.tsx
+++ b/ui/src/MemeUpload.tsx
@@ -75,7 +75,7 @@ function MemeUpload(props: MemeProps) {
               memeName: timestamp,
               imageId: props.imageID,
               memeUrl: dataUrl,
-              userId: cookies.userId
+              userId: cookies.userId,
             },
             { headers: { Authorization: cookies.userToken } }
           )

--- a/ui/src/NavBar.tsx
+++ b/ui/src/NavBar.tsx
@@ -13,7 +13,12 @@ import { useCookies } from "react-cookie";
 function NavBar() {
   const [searchCriteria, setSearchCriteria] = useState("");
   const history = useHistory();
-  const [cookies, setCookie] = useCookies(["userToken"]);
+  const [cookies, setCookie] = useCookies(["userToken", "username"]);
+
+  let displayUser =
+    cookies.username !== undefined && cookies.username !== "username"
+      ? cookies.username
+      : "Login";
 
   function submitHandler(event: any) {
     event.preventDefault();
@@ -27,6 +32,7 @@ function NavBar() {
 
   function onLogout() {
     setCookie("userToken", "not logged in", { path: "/" });
+    setCookie("username", "username", { path: "/" });
     history.push("/login");
   }
 
@@ -36,6 +42,15 @@ function NavBar() {
       history.push("/login");
     } else {
       history.push("/create-meme");
+    }
+  }
+
+  function goToSettings() {
+    if (cookies.userToken === "not logged in") {
+      alert("You must be logged in to access this page");
+      history.push("/login");
+    } else {
+      history.push("/user/settings");
     }
   }
 
@@ -61,10 +76,11 @@ function NavBar() {
           </Button>
         </Form>
 
-        <NavDropdown title="Login" id="basic-nav-dropdown">
+        <NavDropdown title={displayUser} id="basic-nav-dropdown">
           <NavDropdown.Item href="/login">Login</NavDropdown.Item>
           <NavDropdown.Item href="/sign-up">Sign-Up</NavDropdown.Item>
           <NavDropdown.Item onClick={onLogout}>Log-Out</NavDropdown.Item>
+          <NavDropdown.Item onClick={goToSettings}>Settings</NavDropdown.Item>
         </NavDropdown>
       </Navbar.Collapse>
     </Navbar>

--- a/ui/src/UserSettings.css
+++ b/ui/src/UserSettings.css
@@ -1,0 +1,14 @@
+.settings {
+  text-align: center;
+}
+
+.settingsHeader {
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}

--- a/ui/src/UserSettings.tsx
+++ b/ui/src/UserSettings.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import axios from "axios";
+import "./UserSettings.css";
+import { useCookies } from "react-cookie";
+import * as Yup from "yup";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+import FormControl from "react-bootstrap/FormControl";
+import Button from "react-bootstrap/Button";
+import { useFormik } from "formik";
+import { useHistory } from "react-router-dom";
+import NavBar from "./NavBar";
+
+const validationSchema = Yup.object({
+  username: Yup.string().when("password", {
+    is: (value) => !value || value.length === 0,
+    then: Yup.string().email().max(30).required("Required"),
+  }),
+  password: Yup.string()
+    .min(8)
+    .max(50)
+    .matches(
+      /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,})/,
+      "Password must have 8 characters, 1 lowercase, 1 uppercase, 1 number, and 1 special character"
+    ),
+  confirmPassword: Yup.string().when("password", {
+    is: (value) => value && value.length > 0,
+    then: Yup.string()
+      .oneOf([Yup.ref("password"), null], "Passwords must match")
+      .required("Required"),
+  }),
+});
+
+function UserSettings(props: any) {
+  const [cookies, setCookie] = useCookies(["userToken", "userId", "username"]);
+  const history = useHistory();
+
+  const { handleSubmit, handleChange, values, errors } = useFormik({
+    initialValues: {
+      username: "",
+      password: "",
+      confirmPassword: "",
+    },
+    validationSchema,
+    onSubmit(values) {
+      const username = values.username;
+      const password = values.password;
+      values.username = "";
+      values.password = "";
+      values.confirmPassword = "";
+      axios
+        .put(
+          "http://localhost:8080/users/settings",
+          {
+            id: cookies.userId,
+            username: username,
+            password: password,
+          },
+          { headers: { Authorization: cookies.userToken } }
+        )
+        .then((res) => {
+          if (res.data === "User has been updated") {
+            if (username.length > 0) {
+              setCookie("username", username, { path: "/" });
+            }
+            history.push(`/user/settings`);
+            alert("User has been updated");
+          } else {
+            alert("Error updating settings");
+          }
+        });
+    },
+  });
+
+  return (
+    <div className="settings">
+      <NavBar></NavBar>
+      <header className="settingsHeader">
+        <Button href="/create-meme" variant="primary">
+          Home
+        </Button>
+        <h1>View and Edit your Settings</h1>
+        <Form onSubmit={handleSubmit}>
+          <InputGroup>
+            <InputGroup.Prepend>
+              <InputGroup.Text>Username</InputGroup.Text>
+            </InputGroup.Prepend>
+            <FormControl
+              type="text"
+              name="username"
+              placeholder={cookies.username}
+              onChange={handleChange}
+              value={values.username}
+            />
+          </InputGroup>
+          <p style={{ color: "red" }}>
+            {errors.username ? errors.username : null}
+          </p>
+          <br></br>
+          <InputGroup>
+            <InputGroup.Prepend>
+              <InputGroup.Text>Change Password</InputGroup.Text>
+            </InputGroup.Prepend>
+            <FormControl
+              type="password"
+              name="password"
+              placeholder="Password..."
+              onChange={handleChange}
+              value={values.password}
+            />
+          </InputGroup>
+          <p style={{ color: "red" }}>
+            {errors.password ? errors.password : null}
+          </p>
+          <br></br>
+          <InputGroup>
+            <InputGroup.Prepend>
+              <InputGroup.Text>Confirm Change Password</InputGroup.Text>
+            </InputGroup.Prepend>
+            <FormControl
+              type="password"
+              name="confirmPassword"
+              placeholder="Confirm Password..."
+              onChange={handleChange}
+              value={values.confirmPassword}
+            />
+          </InputGroup>
+          <p style={{ color: "red" }}>
+            {errors.confirmPassword ? errors.confirmPassword : null}
+          </p>
+          <Button type="submit" variant="primary">
+            Update Settings
+          </Button>
+        </Form>
+      </header>
+    </div>
+  );
+}
+
+export default UserSettings;


### PR DESCRIPTION
This pr adds the user settings page which allows them to view and edit their username as well as editing their password. As more information gets associated to a user, this page will get updated.

This also adds the username displayed in the top right of the navbar when logged in.

This relates to issue #10 

Validation is added with the formik package in the frontend, but there is backend validation added as well.