### PR TITLE
fix the bug in user dashboard that put new memes at the bottom

### DIFF
--- a/api/src/main/java/com/exelaration/abstractmemery/repositories/MemeRepository.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/repositories/MemeRepository.java
@@ -14,5 +14,5 @@ public interface MemeRepository extends JpaRepository<Meme, Integer> {
       findTop10ByTopTextIgnoreCaseContainsOrBottomTextIgnoreCaseContainsOrMemeNameIgnoreCaseContains(
           String topText, String bottomText, String memeName);
 
-  ArrayList<Meme> findByUserId(int userId);
+  ArrayList<Meme> findByUserIdOrderByIdDesc(int userId);
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeMetadataServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeMetadataServiceImpl.java
@@ -34,7 +34,7 @@ public class MemeMetadataServiceImpl implements MemeMetadataService {
   }
 
   public ArrayList<Meme> getUserMemes(int userId) {
-    return memeRepository.findByUserId(userId);
+    return memeRepository.findByUserIdOrderByIdDesc(userId);
   }
 
   public ArrayList<Meme> findByText(String text) throws Exception {

--- a/api/src/test/java/com/exelaration/abstractmemery/services/MemeMetadataServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/MemeMetadataServiceTest.java
@@ -45,7 +45,7 @@ public class MemeMetadataServiceTest {
 
   @Test
   public void getUserMemes__WhenReturnsNull_expectEmptyArray() {
-    Mockito.when(memeRepository.findByUserId(1)).thenReturn(null);
+    Mockito.when(memeRepository.findByUserIdOrderByIdDesc(1)).thenReturn(null);
 
     assertNull(memeMetadataService.getUserMemes(1));
   }
@@ -58,7 +58,7 @@ public class MemeMetadataServiceTest {
     expectedMemes.add(testMeme);
     String expectedFirstMemeName = expectedMemes.get(0).getMemeName();
 
-    Mockito.when(memeRepository.findByUserId(1)).thenReturn(expectedMemes);
+    Mockito.when(memeRepository.findByUserIdOrderByIdDesc(1)).thenReturn(expectedMemes);
     String actualFirstMemeName = memeMetadataService.getUserMemes(1).get(0).getMemeName();
 
     assertEquals(expectedFirstMemeName, actualFirstMemeName);


### PR DESCRIPTION
This PR adjusts the user dashboard query to order the meme IDs in descending order so that new memes are on the top instead of the bottom. This matches the functionality of the public gallery.