### PR TITLE
add meme creation from existing memes

### DIFF
--- a/api/src/main/java/com/exelaration/abstractmemery/controllers/UploadController.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/controllers/UploadController.java
@@ -2,7 +2,9 @@ package com.exelaration.abstractmemery.controllers;
 
 import com.exelaration.abstractmemery.domains.Image;
 import com.exelaration.abstractmemery.services.ImageService;
+import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,5 +20,10 @@ public class UploadController {
   public Image uploadData(@RequestParam("file") MultipartFile file) throws Exception {
 
     return imageService.save(file);
+  }
+
+  @GetMapping()
+  public ArrayList<Image> getImagesForUpload() {
+    return imageService.getImages();
   }
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/FileStorageService.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/FileStorageService.java
@@ -4,5 +4,5 @@ public interface FileStorageService {
 
   public void save(String fileName, String urlData, String storageLocation);
 
-  public String getFileData(String fileName);
+  public String getFileData(String fileName, String fileType);
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/ImageService.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/ImageService.java
@@ -2,6 +2,7 @@ package com.exelaration.abstractmemery.services;
 
 import com.exelaration.abstractmemery.domains.Image;
 import java.io.IOException;
+import java.util.ArrayList;
 import javax.transaction.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,4 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageService {
 
   public Image save(MultipartFile file) throws IOException;
+
+  public ArrayList<Image> getImages();
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/FileStorageServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/FileStorageServiceImpl.java
@@ -31,8 +31,8 @@ public class FileStorageServiceImpl implements FileStorageService {
     }
   }
 
-  public String getFileData(String fileName) {
-    String fileLocation = uploadingDir + "memes/";
+  public String getFileData(String fileName, String fileType) {
+    String fileLocation = uploadingDir + fileType;
     File file = new File(fileLocation + fileName);
     String fileData = "";
     if (file.exists()) {

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/ImageServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/ImageServiceImpl.java
@@ -4,10 +4,15 @@ import com.exelaration.abstractmemery.domains.Image;
 import com.exelaration.abstractmemery.services.FileStorageService;
 import com.exelaration.abstractmemery.services.ImageService;
 import com.exelaration.abstractmemery.services.MetadataService;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service("imageService")
 public class ImageServiceImpl implements ImageService {
@@ -15,6 +20,8 @@ public class ImageServiceImpl implements ImageService {
   @Autowired private FileStorageService fileStorageService;
 
   @Autowired private MetadataService metadataService;
+
+  private final String fileType = "images/";
 
   public Image save(MultipartFile file) {
     Image image = new Image();
@@ -32,11 +39,37 @@ public class ImageServiceImpl implements ImageService {
       e.printStackTrace();
     }
     try {
+      String timeStamp = new Date().getTime() + "";
+      int index = fileName.indexOf(".");
+      fileName = fileName.substring(0, index) + "-" + timeStamp + fileName.substring(index);
+      image.setFileName(fileName);
       fileStorageService.save(fileName, fileData, "images/");
       return metadataService.save(image);
 
     } catch (Exception e) {
       return null;
     }
+  }
+
+  public ArrayList<Image> getImages() {
+    List<Image> images = metadataService.findAll();
+    return getImagesFromFileSystem(images);
+  }
+
+  private ArrayList<Image> getImagesFromFileSystem(List<Image> images) {
+    if (images == null) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Images Do Not Exist");
+    }
+    ArrayList<Image> imagesWithData = new ArrayList<Image>();
+    for (Image image : images) {
+      try {
+        String imageData = fileStorageService.getFileData(image.getFileName(), fileType);
+        image.setFileData(imageData);
+        imagesWithData.add(image);
+      } catch (Exception e) {
+        return null;
+      }
+    }
+    return imagesWithData;
   }
 }

--- a/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeServiceImpl.java
+++ b/api/src/main/java/com/exelaration/abstractmemery/services/implementations/MemeServiceImpl.java
@@ -20,6 +20,8 @@ public class MemeServiceImpl implements MemeService {
   @Autowired private MemeMetadataService memeMetadataService;
   @Autowired private FileStorageService fileStorageService;
 
+  private final String fileType = "memes/";
+
   public Meme save(Meme meme) {
     try {
       String memeUrl = meme.getMemeUrl();
@@ -42,7 +44,7 @@ public class MemeServiceImpl implements MemeService {
     }
     try {
       String memeName = meme.get().getMemeName();
-      memeData = fileStorageService.getFileData(memeName);
+      memeData = fileStorageService.getFileData(memeName, fileType);
     } catch (Exception e) {
       return null;
     }
@@ -67,7 +69,7 @@ public class MemeServiceImpl implements MemeService {
     ArrayList<Meme> memesWithData = new ArrayList<Meme>();
     for (Meme meme : memes) {
       try {
-        String memeData = fileStorageService.getFileData(meme.getMemeName());
+        String memeData = fileStorageService.getFileData(meme.getMemeName(), fileType);
         meme.setMemeUrl(memeData);
         memesWithData.add(meme);
       } catch (Exception e) {
@@ -86,7 +88,7 @@ public class MemeServiceImpl implements MemeService {
       ArrayList<Meme> memesWithData = new ArrayList<Meme>();
       for (Meme meme : memes) {
         try {
-          String memeData = fileStorageService.getFileData(meme.getMemeName());
+          String memeData = fileStorageService.getFileData(meme.getMemeName(), fileType);
           meme.setMemeUrl(memeData);
           memesWithData.add(meme);
         } catch (Exception e) {

--- a/api/src/test/java/com/exelaration/abstractmemery/services/ImageServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/ImageServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 
 import com.exelaration.abstractmemery.domains.Image;
 import com.exelaration.abstractmemery.services.implementations.ImageServiceImpl;
+import java.util.ArrayList;
+import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,12 +35,14 @@ public class ImageServiceTest {
 
   @Test
   public void save_WhenImageSavedSuccessfully_ExpectImageReturned() {
+    String timeStamp = new Date().getTime() + "";
+    String fileName = "test-image-" + timeStamp + ".png";
     MockMultipartFile mockMultipartFile =
-        new MockMultipartFile(
-            "user-image", "test-image.png", "image/png", "test-image.png".getBytes());
+        new MockMultipartFile("user-image", fileName, "image/png", fileName.getBytes());
 
     Image expectedImage = new Image();
-    expectedImage.setFileName("test-image.png");
+
+    expectedImage.setFileName(fileName);
     expectedImage.setFileData("imageData");
 
     Mockito.when(metadataService.save(Mockito.any())).thenReturn(expectedImage);
@@ -46,8 +50,7 @@ public class ImageServiceTest {
     Image actualImage = imageService.save(mockMultipartFile);
 
     assertEquals(expectedImage.getFileName(), actualImage.getFileName());
-    verify(fileStorageService)
-        .save(Mockito.eq("test-image.png"), Mockito.any(), Mockito.eq("images/"));
+    verify(fileStorageService).save(Mockito.any(), Mockito.any(), Mockito.eq("images/"));
   }
 
   @Test
@@ -70,5 +73,91 @@ public class ImageServiceTest {
         .when(fileStorageService)
         .save(Mockito.any(), Mockito.any(), Mockito.any());
     assertNull(imageService.save(mockMultipartFile));
+  }
+
+  public void getImages_WhenFileStorageServiceThrowsException_expectNull() {
+    ArrayList<Image> expectedImages = new ArrayList<Image>();
+    Image testImage = new Image();
+    testImage.setFileName("testImage");
+    expectedImages.add(testImage);
+
+    Mockito.when(metadataService.findAll()).thenReturn(expectedImages);
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .getFileData(Mockito.any(), Mockito.any());
+    assertNull(imageService.getImages());
+  }
+
+  @Test
+  public void getImages_WhenSuccessful_expectImageURLs() {
+    ArrayList<Image> expectedImages = new ArrayList<Image>();
+    Image testImage = new Image();
+    testImage.setFileName("testImage");
+    expectedImages.add(testImage);
+    String imageURL = "testImageURL";
+
+    ArrayList<String> expectedURLs = new ArrayList<String>();
+    expectedURLs.add("testImageURL");
+    Mockito.when(metadataService.findAll()).thenReturn(expectedImages);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(imageURL);
+    assertEquals(expectedURLs.get(0), imageService.getImages().get(0).getFileData());
+  }
+
+  @Test
+  public void getImages_WhenImagesDoNotExistLocally_expectNullImages() {
+    ArrayList<Image> expectedImages = new ArrayList<Image>();
+    Image testImage = new Image();
+    testImage.setFileName("testImage");
+    expectedImages.add(testImage);
+    String imageURL = null;
+
+    ArrayList<String> expectedURLs = new ArrayList<String>();
+    expectedURLs.add(imageURL);
+    Mockito.when(metadataService.findAll()).thenReturn(expectedImages);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(imageURL);
+    assertEquals(expectedURLs.get(0), imageService.getImages().get(0).getFileData());
+  }
+
+  @Test
+  public void getImages_WhenSomeImagesExistLocally_expectSomeImages() {
+    String imageURL1 = "testImageURL1";
+    String imageURL2 = null;
+    String imageURL3 = "testImageURL3";
+    String fileType = "images/";
+
+    ArrayList<Image> expectedImages = new ArrayList<Image>();
+    Image expectedImage1 = new Image();
+    expectedImage1.setFileName("testImage1");
+    expectedImage1.setFileData(imageURL1);
+    expectedImages.add(expectedImage1);
+    Image expectedImage2 = new Image();
+    expectedImage2.setFileName("testImage2");
+    expectedImage2.setFileData(imageURL2);
+    expectedImages.add(expectedImage2);
+    Image expectedImage3 = new Image();
+    expectedImage3.setFileName("testImage3");
+    expectedImage3.setFileData(imageURL3);
+    expectedImages.add(expectedImage3);
+
+    String expectedImageUrl1 = expectedImage1.getFileData();
+    String expectedImageUrl2 = expectedImage2.getFileData();
+    String expectedImageUrl3 = expectedImage3.getFileData();
+
+    Mockito.when(metadataService.findAll()).thenReturn(expectedImages);
+    Mockito.when(fileStorageService.getFileData(expectedImage1.getFileName(), fileType))
+        .thenReturn(expectedImageUrl1);
+    Mockito.when(fileStorageService.getFileData(expectedImage2.getFileName(), fileType))
+        .thenReturn(expectedImageUrl2);
+    Mockito.when(fileStorageService.getFileData(expectedImage3.getFileName(), fileType))
+        .thenReturn(expectedImageUrl3);
+
+    ArrayList<Image> actualImages = imageService.getImages();
+    String actualImageUrl1 = actualImages.get(0).getFileData();
+    String actualImageUrl2 = actualImages.get(1).getFileData();
+    String actualImageUrl3 = actualImages.get(2).getFileData();
+
+    assertEquals(expectedImageUrl1, actualImageUrl1);
+    assertEquals(expectedImageUrl2, actualImageUrl2);
+    assertEquals(expectedImageUrl3, actualImageUrl3);
   }
 }

--- a/api/src/test/java/com/exelaration/abstractmemery/services/MemeServiceTest.java
+++ b/api/src/test/java/com/exelaration/abstractmemery/services/MemeServiceTest.java
@@ -89,12 +89,13 @@ public class MemeServiceTest {
   @Test
   public void getMeme_WhenMemeExists_ExpectMemeDisplayed() {
     String fileName = "test-file";
+    String fileType = "memes/";
     Meme mockMeme = new Meme();
     mockMeme.setMemeName(fileName);
     String expectedImageData = "image data";
 
     when(memeMetadataService.findById(5)).thenReturn(Optional.of(mockMeme));
-    when(fileStorageService.getFileData(fileName)).thenReturn(expectedImageData);
+    when(fileStorageService.getFileData(fileName, fileType)).thenReturn(expectedImageData);
     String actualImageData = memeService.getMeme(5);
 
     assertEquals(expectedImageData, actualImageData);
@@ -137,9 +138,10 @@ public class MemeServiceTest {
     Meme testMeme = new Meme();
     testMeme.setMemeName("testMeme");
     expectedMemes.add(testMeme);
-
     Mockito.when(memeMetadataService.findAll(Mockito.any())).thenReturn(expectedMemes);
-    doThrow(new RuntimeException()).when(fileStorageService).getFileData(Mockito.any());
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .getFileData(Mockito.any(), Mockito.any());
     assertNull(memeService.getMemes(page));
   }
 
@@ -155,7 +157,7 @@ public class MemeServiceTest {
     ArrayList<String> expectedURLs = new ArrayList<String>();
     expectedURLs.add("testMemeURL");
     Mockito.when(memeMetadataService.findAll(Mockito.any())).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     assertEquals(expectedURLs.get(0), memeService.getMemes(page).get(0).getMemeUrl());
   }
 
@@ -171,7 +173,7 @@ public class MemeServiceTest {
     ArrayList<String> expectedURLs = new ArrayList<String>();
     expectedURLs.add(memeURL);
     Mockito.when(memeMetadataService.findAll(Mockito.any())).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     assertEquals(expectedURLs.get(0), memeService.getMemes(page).get(0).getMemeUrl());
   }
 
@@ -180,6 +182,7 @@ public class MemeServiceTest {
     String memeURL1 = "testMemeURL1";
     String memeURL2 = null;
     String memeURL3 = "testMemeURL3";
+    String fileType = "memes/";
 
     ArrayList<Meme> expectedMemes = new ArrayList<Meme>();
     Meme expectedMeme1 = new Meme();
@@ -200,11 +203,11 @@ public class MemeServiceTest {
     String expectedMemeUrl3 = expectedMeme3.getMemeUrl();
 
     Mockito.when(memeMetadataService.findAll(Mockito.any())).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(expectedMeme1.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme1.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl1);
-    Mockito.when(fileStorageService.getFileData(expectedMeme2.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme2.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl2);
-    Mockito.when(fileStorageService.getFileData(expectedMeme3.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme3.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl3);
 
     int page = 0;
@@ -227,7 +230,9 @@ public class MemeServiceTest {
     expectedMemes.add(testMeme);
 
     Mockito.when(memeMetadataService.getUserMemes(userId)).thenReturn(expectedMemes);
-    doThrow(new RuntimeException()).when(fileStorageService).getFileData(Mockito.any());
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .getFileData(Mockito.any(), Mockito.any());
     assertNull(memeService.getUserMemes(userId));
   }
 
@@ -244,7 +249,7 @@ public class MemeServiceTest {
     String expectedMemeUrl = expectedURLs.get(0);
 
     Mockito.when(memeMetadataService.getUserMemes(userId)).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     String actualMemeUrl = memeService.getUserMemes(userId).get(0).getMemeUrl();
 
     assertEquals(expectedMemeUrl, actualMemeUrl);
@@ -263,7 +268,7 @@ public class MemeServiceTest {
     String expectedMemeUrl = expectedURLs.get(0);
 
     Mockito.when(memeMetadataService.getUserMemes(userId)).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     String actualMemeUrl = memeService.getUserMemes(userId).get(0).getMemeUrl();
 
     assertEquals(expectedMemeUrl, actualMemeUrl);
@@ -272,6 +277,7 @@ public class MemeServiceTest {
   @Test
   public void getUserMemes_WhenSomeMemesExistLocally_expectSomeMemes() {
     int userId = 1;
+    String fileType = "memes/";
     String memeURL1 = "testMemeURL1";
     String memeURL2 = null;
     String memeURL3 = "testMemeURL3";
@@ -294,11 +300,11 @@ public class MemeServiceTest {
     String expectedMemeUrl3 = expectedMeme3.getMemeUrl();
 
     Mockito.when(memeMetadataService.getUserMemes(userId)).thenReturn(expectedMemes);
-    Mockito.when(fileStorageService.getFileData(expectedMeme1.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme1.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl1);
-    Mockito.when(fileStorageService.getFileData(expectedMeme2.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme2.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl2);
-    Mockito.when(fileStorageService.getFileData(expectedMeme3.getMemeName()))
+    Mockito.when(fileStorageService.getFileData(expectedMeme3.getMemeName(), fileType))
         .thenReturn(expectedMemeUrl3);
 
     ArrayList<Meme> actualMemes = memeService.getUserMemes(userId);
@@ -318,7 +324,9 @@ public class MemeServiceTest {
     actualMemes.add(testMeme);
 
     Mockito.when(memeMetadataService.findByText("test")).thenReturn(actualMemes);
-    doThrow(new RuntimeException()).when(fileStorageService).getFileData(Mockito.any());
+    doThrow(new RuntimeException())
+        .when(fileStorageService)
+        .getFileData(Mockito.any(), Mockito.any());
     assertNull(memeService.getMemesWithText("test"));
   }
 
@@ -331,7 +339,7 @@ public class MemeServiceTest {
     actualMemes.add(testMeme);
 
     Mockito.when(memeMetadataService.findByText("test")).thenReturn(actualMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     assertEquals(memeURL, memeService.getMemesWithText("test").get(0).getMemeUrl());
   }
 
@@ -344,7 +352,7 @@ public class MemeServiceTest {
     String memeURL = null;
 
     Mockito.when(memeMetadataService.findByText("test")).thenReturn(actualMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any())).thenReturn(memeURL);
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any())).thenReturn(memeURL);
     assertEquals(memeURL, memeService.getMemesWithText("test").get(0).getMemeUrl());
   }
 
@@ -373,7 +381,7 @@ public class MemeServiceTest {
     expectedMemes.add(meme3);
 
     Mockito.when(memeMetadataService.findByText("test")).thenReturn(actualMemes);
-    Mockito.when(fileStorageService.getFileData(Mockito.any()))
+    Mockito.when(fileStorageService.getFileData(Mockito.any(), Mockito.any()))
         .thenReturn(meme1.getMemeUrl())
         .thenReturn("")
         .thenReturn(meme3.getMemeUrl());

--- a/ui/src/ExistingImages.css
+++ b/ui/src/ExistingImages.css
@@ -1,0 +1,4 @@
+img {
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/ui/src/ExistingImages.tsx
+++ b/ui/src/ExistingImages.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import axios from "axios";
+import { Button, Modal, Spinner } from "react-bootstrap";
+import "./ExistingImages.css";
+
+type ExistingImagesProps = {
+  handleImageData: CallableFunction;
+  handleImageId: CallableFunction;
+};
+interface ImageResponse {
+  fileData: string;
+  fileName: string;
+  id: number;
+}
+
+function ExistingImages(props: ExistingImagesProps) {
+  const [show, setShow] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [imageResponses, setImageResponses] = useState([]);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => {
+    axios.get("http://localhost:8080/upload").then((response) => {
+      const imageResponses = response.data;
+      setImageResponses(imageResponses);
+      setLoading(false);
+    });
+    setShow(true);
+  };
+
+  function imageClick(image: ImageResponse) {
+    props.handleImageId(image["id"]);
+    props.handleImageData(image["fileData"]);
+    handleClose();
+  }
+
+  const loadingState = (
+    <Spinner variant="primary" animation="border" role="status">
+      <span className="sr-only">Loading...</span>
+    </Spinner>
+  );
+
+  const images = imageResponses.map(function (image) {
+    return (
+      <div key={image["id"]}>
+        {" "}
+        <img
+          className="modalImage"
+          src={"data:image/jpeg;base64," + image["fileData"]}
+          alt="Not Found"
+          onClick={() => imageClick(image)}
+        />
+      </div>
+    );
+  });
+
+  return (
+    <>
+      <Button variant="secondary" onClick={handleShow} size="lg">
+        Browse Existing Images
+      </Button>
+
+      <Modal show={show} onHide={handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Select An Image As A Meme Template</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {loading && loadingState}
+          <ul>{images}</ul>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outline-primary" onClick={handleClose}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+
+export default ExistingImages;

--- a/ui/src/ImageUpload.tsx
+++ b/ui/src/ImageUpload.tsx
@@ -7,6 +7,7 @@ import InputGroup from "react-bootstrap/InputGroup";
 import "./ImageUpload.css";
 import MemeContent from "./MemeContent";
 import { useCookies } from "react-cookie";
+import ExistingImages from "./ExistingImages";
 
 type ImageProps = {
   topText: string;
@@ -66,6 +67,14 @@ function ImageUpload(props: ImageProps) {
     return file["type"].split("/")[0] === "image"; //returns true or false
   }
 
+  function sendImageData(imageData: string) {
+    setImageData(imageData);
+  }
+
+  function sendImageId(id: number) {
+    dispatch({ type: AppActions.updateImageID, value: id });
+  }
+
   return (
     <div className="upload">
       <MemeContent
@@ -90,6 +99,10 @@ function ImageUpload(props: ImageProps) {
             </Button>
           </InputGroup.Append>
         </InputGroup>
+        <ExistingImages
+          handleImageData={sendImageData}
+          handleImageId={sendImageId}
+        ></ExistingImages>
       </Form>
     </div>
   );


### PR DESCRIPTION
This pr relates to issue #79 and allows the user to browse existing uploaded images to choose as a template for meme creation rather than uploading their own image. 

Another feature that could be added here is pagination, but that could be done in another pr.